### PR TITLE
Ignore comma on day_picker_test.dart

### DIFF
--- a/test/home/meals/components/day_picker_test.dart
+++ b/test/home/meals/components/day_picker_test.dart
@@ -37,6 +37,7 @@ void main() {
     expect(() {
       // Not the same Week
       week.setDay(dayOnNextWeek);
+      // ignore: require_trailing_commas
     }, throwsA(isA<IllegalArgumentsException>()));
 
     final otherWeek = DayPickerWeek.fromDay(dayOnNextWeek);


### PR DESCRIPTION
"dart format" removes comma,
"dart fix" adds comma,
"flutter analyze" required comma.

Seems to be a bug, ignoring this line